### PR TITLE
fixed links to template.json & site.css in 09 readme

### DIFF
--- a/09-replace-onlyif-after/README.md
+++ b/09-replace-onlyif-after/README.md
@@ -4,7 +4,7 @@ The sample in this folder demonstrates:
 
 In this sample, we show how you can replace a 
 
-From [`site.css`](./MyProject.StarterWeb/wwwroot/css/site.css)
+From [`site.css`](./MyProject.Con/site.css)
 
 ```
 body {
@@ -32,5 +32,5 @@ textarea {
 The sample shows how you can update the `black` for background-color without impacting the values for color in the following elements.
 
 
-See [`template.json`](./MyProject.StarterWeb/.template.config/template.json)
+See [`template.json`](./MyProject.Con/.template.config/template.json)
 


### PR DESCRIPTION
I noticed the links on https://github.com/dotnet/dotnet-template-samples/tree/master/09-replace-onlyif-after were getting 404, updated to the proper files